### PR TITLE
Added new field AssignedRoom to Dweller 

### DIFF
--- a/ShelterViewer.Shared/Components/Dwellers/DwellerInfo_Dialog.razor
+++ b/ShelterViewer.Shared/Components/Dwellers/DwellerInfo_Dialog.razor
@@ -19,7 +19,7 @@
                         <MudText>Experience: @Dweller.experience.experienceValue</MudText>
                         <MudText>Wasteland Experience: @Dweller.experience.wastelandExperience</MudText>
                         <MudText>Health: <HealthComponent DwellerHealth="Dweller.health" /></MudText>
-                        <MudText>Room: @(VaultService.GetRoom(Dweller.savedRoom)?.type ?? "Coffee Break")</MudText>
+                        <MudText>Room: @(VaultService.GetRoom(Dweller.AssignedRoom)?.type ?? "Coffee Break")</MudText>
                     </MudItem>
                     <MudItem xs="6">
                         <MudText Typo="Typo.h5">Parents</MudText>

--- a/ShelterViewer.Shared/Models/Dweller.cs
+++ b/ShelterViewer.Shared/Models/Dweller.cs
@@ -42,6 +42,9 @@ public class Dweller
     public int daysOnWasteland { get; set; }
     public int hoursOnWasteland { get; set; }
 
+    // Added fields for display
+    public int AssignedRoom { get; set; }
+
     // Added fields for displaying parents and children
     public string Name { get { return $"{firstName} {lastName}"; } }
     public string Gender { get { return (_gender == 1) ? "Female" : "Male"; } }

--- a/ShelterViewer.Shared/Pages/Dwellers.razor
+++ b/ShelterViewer.Shared/Pages/Dwellers.razor
@@ -54,7 +54,7 @@
             <CellTemplate>
                 <MudText>
                     @{
-                        var room = VaultService.GetRoom(context.Item.savedRoom);
+                        var room = VaultService.GetRoom(context.Item.AssignedRoom);
                     }
                     @(room?.Name ?? "Coffee Break") @if(room != null && !String.IsNullOrEmpty(room.Trait)) { <MudText Inline Color="MatchedRoom(context.Item, room)">@($" ( {room.Trait.FirstOrDefault()} )")</MudText> }
                 </MudText>
@@ -103,7 +103,7 @@
             NavigationManager.NavigateTo("/");
         }
 
-        DwellerList = VaultService.Dwellers;
+        DwellerList = VaultService.DwellerList;
     }
 
     private Task ShowDweller(Dweller selected)


### PR DESCRIPTION
Found that the savedroom is not actually how the game keeps track of where users are assigned.  Populated a new AssignedRoom from the dwellerId list in the rooms and use this for display.

## Release Notes

### Bug Fixes
- Fixed bug with using savedRoom instead of the dwellerId from the room.